### PR TITLE
Use @hightouchio/tedious instead of @tediousjs/tedious

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "debug": "^4.3.3",
         "rfdc": "^1.3.0",
         "tarn": "^3.0.2",
-        "tedious": "^19.0.0"
+        "tedious": "github:hightouchio/tedious"
       },
       "bin": {
         "mssql": "bin/mssql"
@@ -1009,9 +1009,10 @@
       "dev": true
     },
     "node_modules/@js-joda/core": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.2.tgz",
-      "integrity": "sha512-ow4R+7C24xeTjiMTTZ4k6lvxj7MRBqvqLCQjThQff3RjOmIMokMP20LNYVFhGafJtUx/Xo2Qp4qU8eNoTVH0SA=="
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.3.tgz",
+      "integrity": "sha512-T1rRxzdqkEXcou0ZprN1q9yDRlvzCPLqmlNt5IIsGBzoEVgLCCYrKEwc84+TvsXuAc95VAZwtWD2zVsKPY4bcA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1510,9 +1511,10 @@
       "dev": true
     },
     "node_modules/@types/readable-stream": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.14.tgz",
-      "integrity": "sha512-xZn/AuUbCMShGsqH/ehZtGDwQtbx00M9rZ2ENLe4tOjFZ/JFeWMhEZkk2fEe1jAUqqEAURIkFJ7Az/go8mM1/w==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.16.tgz",
+      "integrity": "sha512-Fvp+8OcU8PyV90KTk5tR/rI8OjD3MP5NUow5rjOsZo+9zxf4p4soJtK9j4V6yeG30TH6rZxqRaP4JLa8lNNTNQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "safe-buffer": "~5.1.1"
@@ -1521,12 +1523,14 @@
     "node_modules/@types/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -1853,7 +1857,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
@@ -1871,9 +1876,10 @@
       }
     },
     "node_modules/bl": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.12.tgz",
-      "integrity": "sha512-EnEYHilP93oaOa2MnmNEjAcovPS3JlQZOyzGXi3EyEpPhm9qWvdDp7BmAVEVusGzp8LlwQK56Av+OkDoRjzE0w==",
+      "version": "6.0.16",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.16.tgz",
+      "integrity": "sha512-V/kz+z2Mx5/6qDfRCilmrukUXcXuCoXKg3/3hDvzKKoSUx8CJKudfIoT29XZc3UE9xBvxs5qictiHdprwtteEg==",
+      "license": "MIT",
       "dependencies": {
         "@types/readable-stream": "^4.0.0",
         "buffer": "^6.0.3",
@@ -1933,6 +1939,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -3393,6 +3400,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -4264,7 +4272,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.2.4",
@@ -8822,6 +8831,7 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -8999,6 +9009,7 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
       "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -9922,6 +9933,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -10131,16 +10143,16 @@
       }
     },
     "node_modules/tedious": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-19.0.0.tgz",
-      "integrity": "sha512-nmxNBAT72mMVCIYp0Ts0Zzd5+LBQjoXlqigCrIjSo2OERSi04vr3EHq3qJxv/zgrSkg7si03SoIIfekTAadA7w==",
+      "version": "0.0.0-dev",
+      "resolved": "git+ssh://git@github.com/hightouchio/tedious.git#b6ba5d49ced516e6d9acbf9229713f8fee3a4962",
+      "license": "MIT",
       "dependencies": {
         "@azure/core-auth": "^1.7.2",
         "@azure/identity": "^4.2.1",
         "@azure/keyvault-keys": "^4.4.0",
-        "@js-joda/core": "^5.6.1",
+        "@js-joda/core": "^5.6.3",
         "@types/node": ">=18",
-        "bl": "^6.0.11",
+        "bl": "^6.0.14",
         "iconv-lite": "^0.6.3",
         "js-md4": "^0.3.2",
         "native-duplexpair": "^1.0.0",
@@ -11476,9 +11488,9 @@
       "dev": true
     },
     "@js-joda/core": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.2.tgz",
-      "integrity": "sha512-ow4R+7C24xeTjiMTTZ4k6lvxj7MRBqvqLCQjThQff3RjOmIMokMP20LNYVFhGafJtUx/Xo2Qp4qU8eNoTVH0SA=="
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.3.tgz",
+      "integrity": "sha512-T1rRxzdqkEXcou0ZprN1q9yDRlvzCPLqmlNt5IIsGBzoEVgLCCYrKEwc84+TvsXuAc95VAZwtWD2zVsKPY4bcA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -11873,9 +11885,9 @@
       "dev": true
     },
     "@types/readable-stream": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.14.tgz",
-      "integrity": "sha512-xZn/AuUbCMShGsqH/ehZtGDwQtbx00M9rZ2ENLe4tOjFZ/JFeWMhEZkk2fEe1jAUqqEAURIkFJ7Az/go8mM1/w==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.16.tgz",
+      "integrity": "sha512-Fvp+8OcU8PyV90KTk5tR/rI8OjD3MP5NUow5rjOsZo+9zxf4p4soJtK9j4V6yeG30TH6rZxqRaP4JLa8lNNTNQ==",
       "requires": {
         "@types/node": "*",
         "safe-buffer": "~5.1.1"
@@ -12129,9 +12141,9 @@
       "dev": true
     },
     "bl": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.12.tgz",
-      "integrity": "sha512-EnEYHilP93oaOa2MnmNEjAcovPS3JlQZOyzGXi3EyEpPhm9qWvdDp7BmAVEVusGzp8LlwQK56Av+OkDoRjzE0w==",
+      "version": "6.0.16",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.16.tgz",
+      "integrity": "sha512-V/kz+z2Mx5/6qDfRCilmrukUXcXuCoXKg3/3hDvzKKoSUx8CJKudfIoT29XZc3UE9xBvxs5qictiHdprwtteEg==",
       "requires": {
         "@types/readable-stream": "^4.0.0",
         "buffer": "^6.0.3",
@@ -17947,16 +17959,15 @@
       "integrity": "sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ=="
     },
     "tedious": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-19.0.0.tgz",
-      "integrity": "sha512-nmxNBAT72mMVCIYp0Ts0Zzd5+LBQjoXlqigCrIjSo2OERSi04vr3EHq3qJxv/zgrSkg7si03SoIIfekTAadA7w==",
+      "version": "git+ssh://git@github.com/hightouchio/tedious.git#b6ba5d49ced516e6d9acbf9229713f8fee3a4962",
+      "from": "tedious@github:hightouchio/tedious",
       "requires": {
         "@azure/core-auth": "^1.7.2",
         "@azure/identity": "^4.2.1",
         "@azure/keyvault-keys": "^4.4.0",
-        "@js-joda/core": "^5.6.1",
+        "@js-joda/core": "^5.6.3",
         "@types/node": ">=18",
-        "bl": "^6.0.11",
+        "bl": "^6.0.14",
         "iconv-lite": "^0.6.3",
         "js-md4": "^0.3.2",
         "native-duplexpair": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "debug": "^4.3.3",
     "rfdc": "^1.3.0",
     "tarn": "^3.0.2",
-    "tedious": "^19.0.0"
+    "tedious": "github:hightouchio/tedious"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",


### PR DESCRIPTION
Use our forked version of Tedious instead of the original version. This will incorporate the fix we need into our forked node-mssql library. Once this is merged, we can use logic in the [Hightouch repo](https://github.com/hightouchio/hightouch/pull/17532) to switch between this forked node-mssql library and the original node-mssql library.